### PR TITLE
add datapoints_to_alarm parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ The following values are supported: P1 and P2.
 Defaults to P2.
 
 `datapoints_to_alarm` - The number of datapoints that must be breaching to trigger the alarm. 
-For alarm_type='anomaly_detection' defaults to 10% of evaluation periods.
-For alarm_type='error_detection' defaults to 1.
+Defaults to 1.
 
 `evaluation_periods` - The number of periods over which data is compared to the specified threshold. 
 Defaults to 5.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,44 @@ To add an EFS volume to a lambda use the following fields. Please note lambda sh
 
 `stable_version_weights` - A weight of how much traffic will go to a stable version lambda.
 
+## Alias Variables
+
+`actions_enabled` - Indicates whether the actions should be executed during any changes to the alarm's state. 
+Defaults to true. 
+
+`add_alarm` - Indicates whether the alarm should be added. 
+Defaults to false. 
+
+`alarm_priority` - The priority of the alarm that will be used as prefix to alarm name. 
+The following values are supported: anomaly_detection and error_detection.
+Defaults to error_detection.
+
+`alarm_type` - The type of preconfigured alarm to be added if add_alarm is true 
+The following values are supported: P1 and P2.
+Defaults to P2.
+
+`datapoints_to_alarm` - The number of datapoints that must be breaching to trigger the alarm. 
+For alarm_type='anomaly_detection' defaults to 10% of evaluation periods.
+For alarm_type='error_detection' defaults to 1.
+
+`evaluation_periods` - The number of periods over which data is compared to the specified threshold. 
+Defaults to 5.
+
+`normal_deviation` - The number of standard deviation to be used for the band calculation, i.e. threshold metric. 
+Defaults to 2.
+
+`period` - The period in seconds over which the specified statistic is applied.
+Defaults to 60.
+
+`sns_topic` - The list of actions to execute when this alarm transitions into an ALARM or OK state from any other state. 
+Each action is specified as an Amazon Resource Name (ARN). 
+Defaults to null.
+
+`treat_missing_data` - Sets how this alarm is to handle missing data points. 
+The following values are supported: breaching and notBreaching. 
+Defaults to notBreaching.
+
+
 ## Example #1 - Simple Lambda Function
 
 Assuming:

--- a/alarm.tf
+++ b/alarm.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_metric_alarm" "anomaly_detection" {
   comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
   treat_missing_data  = var.treat_missing_data
   threshold_metric_id = "ad1"
-  datapoints_to_alarm = var.datapoints_to_alarm != 0 ? var.datapoints_to_alarm : ceil(0.1*var.evaluation_periods)
+  datapoints_to_alarm = var.datapoints_to_alarm
   evaluation_periods  = var.evaluation_periods
   actions_enabled     = var.actions_enabled
 
@@ -101,7 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "error_detection" {
   ok_actions          = [var.sns_topic]
   treat_missing_data  = var.treat_missing_data
   threshold           = "0"
-  datapoints_to_alarm = var.datapoints_to_alarm != 0 ? var.datapoints_to_alarm : 1
+  datapoints_to_alarm = var.datapoints_to_alarm
   evaluation_periods  = var.evaluation_periods
   actions_enabled     = var.actions_enabled
 

--- a/alarm.tf
+++ b/alarm.tf
@@ -6,6 +6,7 @@ resource "aws_cloudwatch_metric_alarm" "anomaly_detection" {
   comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
   treat_missing_data  = var.treat_missing_data
   threshold_metric_id = "ad1"
+  datapoints_to_alarm = var.datapoints_to_alarm != 0 ? var.datapoints_to_alarm : ceil(0.1*var.evaluation_periods)
   evaluation_periods  = var.evaluation_periods
   actions_enabled     = var.actions_enabled
 
@@ -100,6 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "error_detection" {
   ok_actions          = [var.sns_topic]
   treat_missing_data  = var.treat_missing_data
   threshold           = "0"
+  datapoints_to_alarm = var.datapoints_to_alarm != 0 ? var.datapoints_to_alarm : 1
   evaluation_periods  = var.evaluation_periods
   actions_enabled     = var.actions_enabled
 

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "actions_enabled" {
 
 variable "datapoints_to_alarm" {
   type    = number
-  default = 0
+  default = 1
 }
 
 variable "evaluation_periods" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,11 @@ variable "actions_enabled" {
   default = true
 }
 
+variable "datapoints_to_alarm" {
+  type    = number
+  default = 0
+}
+
 variable "evaluation_periods" {
   type    = number
   default = 5


### PR DESCRIPTION
If datapoint_to_alarm is not provided then it gets defaulted to same value as evaluation_periods resulting in "not working" alarms in multiple scenarios.
For example, if using error_detection with period=60 and evaluation_periods=60 then datapoint_to_alarm will also 60. As a result the alarm will change state only if all 60 datapoint within 1 Hour will breach the threshold, while in most cases one would use a number much less to trigger the alarm. Thus I want this parameter to be configurable.

Defaults:
~For alarm_type='anomaly_detection' defaults to 10% of evaluation periods.~
~For alarm_type='error_detection' defaults to 1.~

Same default for both alarm types: 1

